### PR TITLE
Change plugin requirement from RPi.GPIO to rpi-lgpio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/nickmitchko/Octoprint-Filament-Reloaded"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ['RPi.GPIO']
+plugin_requires = ['rpi-lgpio']
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
Since the old sysfs GPIO interface is marked as deprecated (in favor of the new gpiochip devices), there is a Python package called rpi-lgpio that ensures compatibility with both: https://rpi-lgpio.readthedocs.io/en/latest/.